### PR TITLE
buster to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,9 @@
     "type": "git",
     "url": "git://github.com/imaya/zlib.js.git"
   },
-  "dependencies" : {
+  "devDependencies" : {
     "buster" : ">=0.6.3"
   },
-  "devDependencies": {},
   "optionalDependencies": {},
   "engines": {
     "node": "*"


### PR DESCRIPTION
this changes buster to be a dev dependency instead of a regular dependency, this means people can require the library without it bringing in the testing framework
